### PR TITLE
Fix the pid file path in dhcp6.init. This fixes "/etc/init.d/dhcpd6 restart"

### DIFF
--- a/dhcp.spec
+++ b/dhcp.spec
@@ -20,7 +20,7 @@ Summary(pl.UTF-8):	Serwer DHCP
 Summary(pt_BR.UTF-8):	Servidor DHCP (Protocolo de configuração dinâmica de hosts)
 Name:		dhcp
 Version:	%{ver}%{pverdot}
-Release:	2
+Release:	3
 Epoch:		4
 License:	MIT
 Group:		Networking/Daemons

--- a/dhcp6.init
+++ b/dhcp6.init
@@ -36,7 +36,7 @@ check_device_up()
 # configtest itself
 configtest() {
 	local rc=0
-	/sbin/dhcpd -6 -t -T -cf /etc/dhcpd6.conf -pf /var/run/dhpcd6.pid || rc=$?
+	/sbin/dhcpd -6 -t -T -cf /etc/dhcpd6.conf -pf /var/run/dhcpd6.pid || rc=$?
 
 	# check if interfaces specified exist and have addresses
 	for i in $DHCPD_INTERFACES; do
@@ -94,7 +94,7 @@ start() {
 
 	checkconfig
 	msg_starting "DHCP IPv6 Server"
-	daemon /sbin/dhcpd -6 -q -cf /etc/dhcpd6.conf -pf /var/run/dhpcd6.pid $DHCPD_INTERFACES
+	daemon /sbin/dhcpd -6 -q -cf /etc/dhcpd6.conf -pf /var/run/dhcpd6.pid $DHCPD_INTERFACES
 	RETVAL=$?
 	[ $RETVAL -eq 0 ] && touch /var/lock/subsys/dhcpd6
 }


### PR DESCRIPTION
- Release: 3